### PR TITLE
"excludeselfxib" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ The `find` command lists all the files that contain unused imports and exits wit
 fui --path=~/source/project/Name find
 ```
 
+#### Find Unused Classes in a Path ignoring self XIB
+
+e.g. a Foo.h will be marked as unused even if a Foo.xib reference the class (and if there is no other reference to Foo.h...)
+
+```
+fui -x --path=~/source/project/Name find
+```
+
 #### Delete All Unused Class Files w/ Prompt
 
 ```

--- a/bin/fui
+++ b/bin/fui
@@ -13,7 +13,9 @@ switch [:x, :excludeselfxib], desc: 'Exclude self xib from search (e.g. if false
 default_command :find
 
 pre do |global_options, command, options, args|
-  $fui = Fui::Finder.new(global_options[:path], global_options[:excludeselfxib])
+  options = global_options.dup
+  path = options.delete(:path)
+  $fui = Fui::Finder.new(path, options)
 end
 
 desc "Find unused classes"

--- a/bin/fui
+++ b/bin/fui
@@ -8,11 +8,12 @@ program_desc 'Find unused imports in an Objective-C codebase'
 
 flag [:p, :path], desc: 'Path to search', default_value: Dir.pwd
 switch [:v, :verbose], desc: 'Verbose', default_value: false
+switch [:x, :excludeselfxib], desc: 'Exclude self xib from search (e.g. if false, Foo.h will be marked as used if a Foo.xib reference the Foo class)', default_value: false
 
 default_command :find
 
 pre do |global_options, command, options, args|
-  $fui = Fui::Finder.new(global_options[:path])
+  $fui = Fui::Finder.new(global_options[:path], global_options[:excludeselfxib])
 end
 
 desc "Find unused classes"

--- a/lib/fui/finder.rb
+++ b/lib/fui/finder.rb
@@ -1,9 +1,10 @@
 module Fui
   class Finder
-    attr_reader :path
+    attr_reader :path, :excludeselfxib
 
-    def initialize(path)
+    def initialize(path, excludeselfxib)
       @path = File.expand_path(path)
+	  @excludeselfxib = excludeselfxib
       raise Errno::ENOENT.new(path) unless Dir.exists?(@path)
     end
 
@@ -60,7 +61,7 @@ module Fui
         yield path if block_given?
         headers.each do |header|
           filename_without_extension = File.basename(path, File.extname(path))
-          references[header] << path if File.read(file).include?("customClass=\"#{header.filename_without_extension}\"")
+          references[header] << path if (!excludeselfxib || filename_without_extension != header.filename_without_extension) && File.read(file).include?("customClass=\"#{header.filename_without_extension}\"")
         end
       end
     end

--- a/lib/fui/finder.rb
+++ b/lib/fui/finder.rb
@@ -1,10 +1,10 @@
 module Fui
   class Finder
-    attr_reader :path, :excludeselfxib
+    attr_reader :path, :options
 
-    def initialize(path, excludeselfxib)
+    def initialize(path, options = {})
       @path = File.expand_path(path)
-	  @excludeselfxib = excludeselfxib
+	  @options = options
       raise Errno::ENOENT.new(path) unless Dir.exists?(@path)
     end
 
@@ -61,7 +61,7 @@ module Fui
         yield path if block_given?
         headers.each do |header|
           filename_without_extension = File.basename(path, File.extname(path))
-          references[header] << path if (!excludeselfxib || filename_without_extension != header.filename_without_extension) && File.read(file).include?("customClass=\"#{header.filename_without_extension}\"")
+          references[header] << path if (!options['excludeselfxib'] || filename_without_extension != header.filename_without_extension) && File.read(file).include?("customClass=\"#{header.filename_without_extension}\"")
         end
       end
     end

--- a/lib/fui/version.rb
+++ b/lib/fui/version.rb
@@ -1,3 +1,3 @@
 module Fui
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end

--- a/lib/fui/version.rb
+++ b/lib/fui/version.rb
@@ -1,3 +1,3 @@
 module Fui
-  VERSION = '0.3.1'
+  VERSION = '0.3.0'
 end

--- a/spec/fixtures/nib/FUINib/FUISubclassOfUIViewUsedInANib.xib
+++ b/spec/fixtures/nib/FUINib/FUISubclassOfUIViewUsedInANib.xib
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="4514" systemVersion="13B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3747"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="1">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Sss-fU-xOs" customClass="FUISubclassOfUIViewUsedInANib">
+                    <rect key="frame" x="0.0" y="-10" width="320" height="568"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                </view>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
+            <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
+        </view>
+        <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="whiteLarge" id="cWh-kb-27A">
+            <rect key="frame" x="0.0" y="0.0" width="37" height="37"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+        </activityIndicatorView>
+    </objects>
+</document>

--- a/spec/fixtures/nibself/FUINib.xcodeproj/project.pbxproj
+++ b/spec/fixtures/nibself/FUINib.xcodeproj/project.pbxproj
@@ -1,0 +1,494 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		3C37E4BA18A54204003BDC99 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C37E4B918A54204003BDC99 /* Foundation.framework */; };
+		3C37E4BC18A54204003BDC99 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C37E4BB18A54204003BDC99 /* CoreGraphics.framework */; };
+		3C37E4BE18A54204003BDC99 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C37E4BD18A54204003BDC99 /* UIKit.framework */; };
+		3C37E4C418A54204003BDC99 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 3C37E4C218A54204003BDC99 /* InfoPlist.strings */; };
+		3C37E4C618A54204003BDC99 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C37E4C518A54204003BDC99 /* main.m */; };
+		3C37E4CA18A54204003BDC99 /* FUIAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C37E4C918A54204003BDC99 /* FUIAppDelegate.m */; };
+		3C37E4CD18A54204003BDC99 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3C37E4CB18A54204003BDC99 /* Main.storyboard */; };
+		3C37E4D018A54204003BDC99 /* FUIViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C37E4CF18A54204003BDC99 /* FUIViewController.m */; };
+		3C37E4D218A54204003BDC99 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3C37E4D118A54204003BDC99 /* Images.xcassets */; };
+		3C37E4D918A54204003BDC99 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C37E4D818A54204003BDC99 /* XCTest.framework */; };
+		3C37E4DA18A54204003BDC99 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C37E4B918A54204003BDC99 /* Foundation.framework */; };
+		3C37E4DB18A54204003BDC99 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C37E4BD18A54204003BDC99 /* UIKit.framework */; };
+		3C37E4E318A54204003BDC99 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 3C37E4E118A54204003BDC99 /* InfoPlist.strings */; };
+		3C37E4E518A54204003BDC99 /* FUINibTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C37E4E418A54204003BDC99 /* FUINibTests.m */; };
+		3C37E4F018A542CC003BDC99 /* FUISubclassOfUIView.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C37E4EF18A542CC003BDC99 /* FUISubclassOfUIView.m */; };
+		3C37E4F218A54341003BDC99 /* FUINibView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3C37E4F118A54341003BDC99 /* FUINibView.xib */; };
+		3C37E4F518A54362003BDC99 /* FUISubclassOfUIViewUsedInANib.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C37E4F418A54362003BDC99 /* FUISubclassOfUIViewUsedInANib.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		3C37E4DC18A54204003BDC99 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3C37E4AE18A54204003BDC99 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3C37E4B518A54204003BDC99;
+			remoteInfo = FUINib;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		3C37E4B618A54204003BDC99 /* FUINib.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FUINib.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		3C37E4B918A54204003BDC99 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		3C37E4BB18A54204003BDC99 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		3C37E4BD18A54204003BDC99 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		3C37E4C118A54204003BDC99 /* FUINib-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "FUINib-Info.plist"; sourceTree = "<group>"; };
+		3C37E4C318A54204003BDC99 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		3C37E4C518A54204003BDC99 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		3C37E4C718A54204003BDC99 /* FUINib-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FUINib-Prefix.pch"; sourceTree = "<group>"; };
+		3C37E4C818A54204003BDC99 /* FUIAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FUIAppDelegate.h; sourceTree = "<group>"; };
+		3C37E4C918A54204003BDC99 /* FUIAppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FUIAppDelegate.m; sourceTree = "<group>"; };
+		3C37E4CC18A54204003BDC99 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		3C37E4CE18A54204003BDC99 /* FUIViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FUIViewController.h; sourceTree = "<group>"; };
+		3C37E4CF18A54204003BDC99 /* FUIViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FUIViewController.m; sourceTree = "<group>"; };
+		3C37E4D118A54204003BDC99 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		3C37E4D718A54204003BDC99 /* FUINibTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FUINibTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3C37E4D818A54204003BDC99 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		3C37E4E018A54204003BDC99 /* FUINibTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "FUINibTests-Info.plist"; sourceTree = "<group>"; };
+		3C37E4E218A54204003BDC99 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		3C37E4E418A54204003BDC99 /* FUINibTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FUINibTests.m; sourceTree = "<group>"; };
+		3C37E4EE18A542CC003BDC99 /* FUISubclassOfUIView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FUISubclassOfUIView.h; sourceTree = "<group>"; };
+		3C37E4EF18A542CC003BDC99 /* FUISubclassOfUIView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FUISubclassOfUIView.m; sourceTree = "<group>"; };
+		3C37E4F118A54341003BDC99 /* FUINibView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = FUINibView.xib; sourceTree = "<group>"; };
+		3C37E4F318A54362003BDC99 /* FUISubclassOfUIViewUsedInANib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FUISubclassOfUIViewUsedInANib.h; sourceTree = "<group>"; };
+		3C37E4F418A54362003BDC99 /* FUISubclassOfUIViewUsedInANib.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FUISubclassOfUIViewUsedInANib.m; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		3C37E4B318A54204003BDC99 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3C37E4BC18A54204003BDC99 /* CoreGraphics.framework in Frameworks */,
+				3C37E4BE18A54204003BDC99 /* UIKit.framework in Frameworks */,
+				3C37E4BA18A54204003BDC99 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3C37E4D418A54204003BDC99 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3C37E4D918A54204003BDC99 /* XCTest.framework in Frameworks */,
+				3C37E4DB18A54204003BDC99 /* UIKit.framework in Frameworks */,
+				3C37E4DA18A54204003BDC99 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		3C37E4AD18A54204003BDC99 = {
+			isa = PBXGroup;
+			children = (
+				3C37E4BF18A54204003BDC99 /* FUINib */,
+				3C37E4DE18A54204003BDC99 /* FUINibTests */,
+				3C37E4B818A54204003BDC99 /* Frameworks */,
+				3C37E4B718A54204003BDC99 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		3C37E4B718A54204003BDC99 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				3C37E4B618A54204003BDC99 /* FUINib.app */,
+				3C37E4D718A54204003BDC99 /* FUINibTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		3C37E4B818A54204003BDC99 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				3C37E4B918A54204003BDC99 /* Foundation.framework */,
+				3C37E4BB18A54204003BDC99 /* CoreGraphics.framework */,
+				3C37E4BD18A54204003BDC99 /* UIKit.framework */,
+				3C37E4D818A54204003BDC99 /* XCTest.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		3C37E4BF18A54204003BDC99 /* FUINib */ = {
+			isa = PBXGroup;
+			children = (
+				3C37E4EE18A542CC003BDC99 /* FUISubclassOfUIView.h */,
+				3C37E4EF18A542CC003BDC99 /* FUISubclassOfUIView.m */,
+				3C37E4C818A54204003BDC99 /* FUIAppDelegate.h */,
+				3C37E4C918A54204003BDC99 /* FUIAppDelegate.m */,
+				3C37E4CB18A54204003BDC99 /* Main.storyboard */,
+				3C37E4CE18A54204003BDC99 /* FUIViewController.h */,
+				3C37E4CF18A54204003BDC99 /* FUIViewController.m */,
+				3C37E4D118A54204003BDC99 /* Images.xcassets */,
+				3C37E4C018A54204003BDC99 /* Supporting Files */,
+				3C37E4F118A54341003BDC99 /* FUINibView.xib */,
+				3C37E4F318A54362003BDC99 /* FUISubclassOfUIViewUsedInANib.h */,
+				3C37E4F418A54362003BDC99 /* FUISubclassOfUIViewUsedInANib.m */,
+			);
+			path = FUINib;
+			sourceTree = "<group>";
+		};
+		3C37E4C018A54204003BDC99 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				3C37E4C118A54204003BDC99 /* FUINib-Info.plist */,
+				3C37E4C218A54204003BDC99 /* InfoPlist.strings */,
+				3C37E4C518A54204003BDC99 /* main.m */,
+				3C37E4C718A54204003BDC99 /* FUINib-Prefix.pch */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		3C37E4DE18A54204003BDC99 /* FUINibTests */ = {
+			isa = PBXGroup;
+			children = (
+				3C37E4E418A54204003BDC99 /* FUINibTests.m */,
+				3C37E4DF18A54204003BDC99 /* Supporting Files */,
+			);
+			path = FUINibTests;
+			sourceTree = "<group>";
+		};
+		3C37E4DF18A54204003BDC99 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				3C37E4E018A54204003BDC99 /* FUINibTests-Info.plist */,
+				3C37E4E118A54204003BDC99 /* InfoPlist.strings */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		3C37E4B518A54204003BDC99 /* FUINib */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3C37E4E818A54204003BDC99 /* Build configuration list for PBXNativeTarget "FUINib" */;
+			buildPhases = (
+				3C37E4B218A54204003BDC99 /* Sources */,
+				3C37E4B318A54204003BDC99 /* Frameworks */,
+				3C37E4B418A54204003BDC99 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = FUINib;
+			productName = FUINib;
+			productReference = 3C37E4B618A54204003BDC99 /* FUINib.app */;
+			productType = "com.apple.product-type.application";
+		};
+		3C37E4D618A54204003BDC99 /* FUINibTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3C37E4EB18A54204003BDC99 /* Build configuration list for PBXNativeTarget "FUINibTests" */;
+			buildPhases = (
+				3C37E4D318A54204003BDC99 /* Sources */,
+				3C37E4D418A54204003BDC99 /* Frameworks */,
+				3C37E4D518A54204003BDC99 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3C37E4DD18A54204003BDC99 /* PBXTargetDependency */,
+			);
+			name = FUINibTests;
+			productName = FUINibTests;
+			productReference = 3C37E4D718A54204003BDC99 /* FUINibTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		3C37E4AE18A54204003BDC99 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				CLASSPREFIX = FUI;
+				LastUpgradeCheck = 0500;
+				ORGANIZATIONNAME = "Daniel Doubrovkine";
+				TargetAttributes = {
+					3C37E4D618A54204003BDC99 = {
+						TestTargetID = 3C37E4B518A54204003BDC99;
+					};
+				};
+			};
+			buildConfigurationList = 3C37E4B118A54204003BDC99 /* Build configuration list for PBXProject "FUINib" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 3C37E4AD18A54204003BDC99;
+			productRefGroup = 3C37E4B718A54204003BDC99 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				3C37E4B518A54204003BDC99 /* FUINib */,
+				3C37E4D618A54204003BDC99 /* FUINibTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		3C37E4B418A54204003BDC99 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3C37E4D218A54204003BDC99 /* Images.xcassets in Resources */,
+				3C37E4C418A54204003BDC99 /* InfoPlist.strings in Resources */,
+				3C37E4CD18A54204003BDC99 /* Main.storyboard in Resources */,
+				3C37E4F218A54341003BDC99 /* FUINibView.xib in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3C37E4D518A54204003BDC99 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3C37E4E318A54204003BDC99 /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		3C37E4B218A54204003BDC99 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3C37E4D018A54204003BDC99 /* FUIViewController.m in Sources */,
+				3C37E4C618A54204003BDC99 /* main.m in Sources */,
+				3C37E4F018A542CC003BDC99 /* FUISubclassOfUIView.m in Sources */,
+				3C37E4CA18A54204003BDC99 /* FUIAppDelegate.m in Sources */,
+				3C37E4F518A54362003BDC99 /* FUISubclassOfUIViewUsedInANib.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3C37E4D318A54204003BDC99 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3C37E4E518A54204003BDC99 /* FUINibTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		3C37E4DD18A54204003BDC99 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3C37E4B518A54204003BDC99 /* FUINib */;
+			targetProxy = 3C37E4DC18A54204003BDC99 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		3C37E4C218A54204003BDC99 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				3C37E4C318A54204003BDC99 /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		3C37E4CB18A54204003BDC99 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				3C37E4CC18A54204003BDC99 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		3C37E4E118A54204003BDC99 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				3C37E4E218A54204003BDC99 /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		3C37E4E618A54204003BDC99 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		3C37E4E718A54204003BDC99 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		3C37E4E918A54204003BDC99 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "FUINib/FUINib-Prefix.pch";
+				INFOPLIST_FILE = "FUINib/FUINib-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Debug;
+		};
+		3C37E4EA18A54204003BDC99 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "FUINib/FUINib-Prefix.pch";
+				INFOPLIST_FILE = "FUINib/FUINib-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Release;
+		};
+		3C37E4EC18A54204003BDC99 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/FUINib.app/FUINib";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "FUINib/FUINib-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "FUINibTests/FUINibTests-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUNDLE_LOADER)";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Debug;
+		};
+		3C37E4ED18A54204003BDC99 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/FUINib.app/FUINib";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "FUINib/FUINib-Prefix.pch";
+				INFOPLIST_FILE = "FUINibTests/FUINibTests-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUNDLE_LOADER)";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		3C37E4B118A54204003BDC99 /* Build configuration list for PBXProject "FUINib" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3C37E4E618A54204003BDC99 /* Debug */,
+				3C37E4E718A54204003BDC99 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3C37E4E818A54204003BDC99 /* Build configuration list for PBXNativeTarget "FUINib" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3C37E4E918A54204003BDC99 /* Debug */,
+				3C37E4EA18A54204003BDC99 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3C37E4EB18A54204003BDC99 /* Build configuration list for PBXNativeTarget "FUINibTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3C37E4EC18A54204003BDC99 /* Debug */,
+				3C37E4ED18A54204003BDC99 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 3C37E4AE18A54204003BDC99 /* Project object */;
+}

--- a/spec/fixtures/nibself/FUINib.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/spec/fixtures/nibself/FUINib.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:FUINib.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/spec/fixtures/nibself/FUINib.xcodeproj/project.xcworkspace/xcshareddata/FUINib.xccheckout
+++ b/spec/fixtures/nibself/FUINib.xcodeproj/project.xcworkspace/xcshareddata/FUINib.xccheckout
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
+	<false/>
+	<key>IDESourceControlProjectIdentifier</key>
+	<string>19B9488F-1DB8-40DD-B3F5-8CDFEAA7088B</string>
+	<key>IDESourceControlProjectName</key>
+	<string>FUINib</string>
+	<key>IDESourceControlProjectOriginsDictionary</key>
+	<dict>
+		<key>EEA74783-2FC7-4259-A59B-61175901C6AB</key>
+		<string>ssh://github.com/dblock/fui.git</string>
+	</dict>
+	<key>IDESourceControlProjectPath</key>
+	<string>spec/fixtures/nib/FUINib/FUINib.xcodeproj/project.xcworkspace</string>
+	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
+	<dict>
+		<key>EEA74783-2FC7-4259-A59B-61175901C6AB</key>
+		<string>../../../../../..</string>
+	</dict>
+	<key>IDESourceControlProjectURL</key>
+	<string>ssh://github.com/dblock/fui.git</string>
+	<key>IDESourceControlProjectVersion</key>
+	<integer>110</integer>
+	<key>IDESourceControlProjectWCCIdentifier</key>
+	<string>EEA74783-2FC7-4259-A59B-61175901C6AB</string>
+	<key>IDESourceControlProjectWCConfigurations</key>
+	<array>
+		<dict>
+			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
+			<string>public.vcs.git</string>
+			<key>IDESourceControlWCCIdentifierKey</key>
+			<string>EEA74783-2FC7-4259-A59B-61175901C6AB</string>
+			<key>IDESourceControlWCCName</key>
+			<string>dblock</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/spec/fixtures/nibself/FUINib.xcodeproj/xcshareddata/xcschemes/FUINib.xcscheme
+++ b/spec/fixtures/nibself/FUINib.xcodeproj/xcshareddata/xcschemes/FUINib.xcscheme
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0500"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3C37E4B518A54204003BDC99"
+               BuildableName = "FUINib.app"
+               BlueprintName = "FUINib"
+               ReferencedContainer = "container:FUINib.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3C37E4D618A54204003BDC99"
+               BuildableName = "FUINibTests.xctest"
+               BlueprintName = "FUINibTests"
+               ReferencedContainer = "container:FUINib.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3C37E4B518A54204003BDC99"
+            BuildableName = "FUINib.app"
+            BlueprintName = "FUINib"
+            ReferencedContainer = "container:FUINib.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3C37E4B518A54204003BDC99"
+            BuildableName = "FUINib.app"
+            BlueprintName = "FUINib"
+            ReferencedContainer = "container:FUINib.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3C37E4B518A54204003BDC99"
+            BuildableName = "FUINib.app"
+            BlueprintName = "FUINib"
+            ReferencedContainer = "container:FUINib.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/spec/fixtures/nibself/FUINib/Base.lproj/Main.storyboard
+++ b/spec/fixtures/nibself/FUINib/Base.lproj/Main.storyboard
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="4514" systemVersion="13B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="vXZ-lx-hvc">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3747"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="ufC-wZ-h7g">
+            <objects>
+                <viewController id="vXZ-lx-hvc" customClass="FUIViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="7TC-ch-pQq"/>
+                        <viewControllerLayoutGuide type="bottom" id="se9-9P-V8b"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="kh9-bI-dsS">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yK2-Ee-jKT" customClass="FUISubclassOfUIView">
+                                <rect key="frame" x="-6" y="5" width="320" height="568"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                            </view>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+    <simulatedMetricsContainer key="defaultSimulatedMetrics">
+        <simulatedStatusBarMetrics key="statusBar"/>
+        <simulatedOrientationMetrics key="orientation"/>
+        <simulatedScreenMetrics key="destination" type="retina4"/>
+    </simulatedMetricsContainer>
+</document>

--- a/spec/fixtures/nibself/FUINib/FUIAppDelegate.h
+++ b/spec/fixtures/nibself/FUINib/FUIAppDelegate.h
@@ -1,0 +1,15 @@
+//
+//  FUIAppDelegate.h
+//  FUINib
+//
+//  Created by Daniel Doubrovkine on 2/7/14.
+//  Copyright (c) 2014 Daniel Doubrovkine. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface FUIAppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+@end

--- a/spec/fixtures/nibself/FUINib/FUIAppDelegate.m
+++ b/spec/fixtures/nibself/FUINib/FUIAppDelegate.m
@@ -1,0 +1,46 @@
+//
+//  FUIAppDelegate.m
+//  FUINib
+//
+//  Created by Daniel Doubrovkine on 2/7/14.
+//  Copyright (c) 2014 Daniel Doubrovkine. All rights reserved.
+//
+
+#import "FUIAppDelegate.h"
+
+@implementation FUIAppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+    // Override point for customization after application launch.
+    return YES;
+}
+							
+- (void)applicationWillResignActive:(UIApplication *)application
+{
+    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+}
+
+- (void)applicationDidEnterBackground:(UIApplication *)application
+{
+    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later. 
+    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+}
+
+- (void)applicationWillEnterForeground:(UIApplication *)application
+{
+    // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+}
+
+- (void)applicationDidBecomeActive:(UIApplication *)application
+{
+    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+}
+
+- (void)applicationWillTerminate:(UIApplication *)application
+{
+    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+}
+
+@end

--- a/spec/fixtures/nibself/FUINib/FUINib-Info.plist
+++ b/spec/fixtures/nibself/FUINib/FUINib-Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>Artsy.${PRODUCT_NAME:rfc1034identifier}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/spec/fixtures/nibself/FUINib/FUINib-Prefix.pch
+++ b/spec/fixtures/nibself/FUINib/FUINib-Prefix.pch
@@ -1,0 +1,16 @@
+//
+//  Prefix header
+//
+//  The contents of this file are implicitly included at the beginning of every source file.
+//
+
+#import <Availability.h>
+
+#ifndef __IPHONE_5_0
+#warning "This project uses features only available in iOS SDK 5.0 and later."
+#endif
+
+#ifdef __OBJC__
+    #import <UIKit/UIKit.h>
+    #import <Foundation/Foundation.h>
+#endif

--- a/spec/fixtures/nibself/FUINib/FUISubclassOfUIView.h
+++ b/spec/fixtures/nibself/FUINib/FUISubclassOfUIView.h
@@ -1,0 +1,13 @@
+//
+//  FUISubclassOfUIView.h
+//  FUINib
+//
+//  Created by Daniel Doubrovkine on 2/7/14.
+//  Copyright (c) 2014 Daniel Doubrovkine. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface FUISubclassOfUIView : UIView
+
+@end

--- a/spec/fixtures/nibself/FUINib/FUISubclassOfUIView.m
+++ b/spec/fixtures/nibself/FUINib/FUISubclassOfUIView.m
@@ -1,0 +1,31 @@
+//
+//  FUISubclassOfUIView.m
+//  FUINib
+//
+//  Created by Daniel Doubrovkine on 2/7/14.
+//  Copyright (c) 2014 Daniel Doubrovkine. All rights reserved.
+//
+
+#import "FUISubclassOfUIView.h"
+
+@implementation FUISubclassOfUIView
+
+- (id)initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
+    if (self) {
+        // Initialization code
+    }
+    return self;
+}
+
+/*
+// Only override drawRect: if you perform custom drawing.
+// An empty implementation adversely affects performance during animation.
+- (void)drawRect:(CGRect)rect
+{
+    // Drawing code
+}
+*/
+
+@end

--- a/spec/fixtures/nibself/FUINib/FUISubclassOfUIViewUsedInANib.h
+++ b/spec/fixtures/nibself/FUINib/FUISubclassOfUIViewUsedInANib.h
@@ -1,0 +1,13 @@
+//
+//  FUISubclassOfUIViewUsedInANib.h
+//  FUINib
+//
+//  Created by Daniel Doubrovkine on 2/7/14.
+//  Copyright (c) 2014 Daniel Doubrovkine. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface FUISubclassOfUIViewUsedInANib : UIView
+
+@end

--- a/spec/fixtures/nibself/FUINib/FUISubclassOfUIViewUsedInANib.m
+++ b/spec/fixtures/nibself/FUINib/FUISubclassOfUIViewUsedInANib.m
@@ -1,0 +1,31 @@
+//
+//  FUISubclassOfUIViewUsedInANib.m
+//  FUINib
+//
+//  Created by Daniel Doubrovkine on 2/7/14.
+//  Copyright (c) 2014 Daniel Doubrovkine. All rights reserved.
+//
+
+#import "FUISubclassOfUIViewUsedInANib.h"
+
+@implementation FUISubclassOfUIViewUsedInANib
+
+- (id)initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
+    if (self) {
+        // Initialization code
+    }
+    return self;
+}
+
+/*
+// Only override drawRect: if you perform custom drawing.
+// An empty implementation adversely affects performance during animation.
+- (void)drawRect:(CGRect)rect
+{
+    // Drawing code
+}
+*/
+
+@end

--- a/spec/fixtures/nibself/FUINib/FUISubclassOfUIViewUsedInANib.xib
+++ b/spec/fixtures/nibself/FUINib/FUISubclassOfUIViewUsedInANib.xib
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="4514" systemVersion="13B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3747"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="1">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Sss-fU-xOs" customClass="FUISubclassOfUIViewUsedInANib">
+                    <rect key="frame" x="0.0" y="-10" width="320" height="568"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                </view>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
+            <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
+        </view>
+        <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="whiteLarge" id="cWh-kb-27A">
+            <rect key="frame" x="0.0" y="0.0" width="37" height="37"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+        </activityIndicatorView>
+    </objects>
+</document>

--- a/spec/fixtures/nibself/FUINib/FUIViewController.h
+++ b/spec/fixtures/nibself/FUINib/FUIViewController.h
@@ -1,0 +1,13 @@
+//
+//  FUIViewController.h
+//  FUINib
+//
+//  Created by Daniel Doubrovkine on 2/7/14.
+//  Copyright (c) 2014 Daniel Doubrovkine. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface FUIViewController : UIViewController
+
+@end

--- a/spec/fixtures/nibself/FUINib/FUIViewController.m
+++ b/spec/fixtures/nibself/FUINib/FUIViewController.m
@@ -1,0 +1,29 @@
+//
+//  FUIViewController.m
+//  FUINib
+//
+//  Created by Daniel Doubrovkine on 2/7/14.
+//  Copyright (c) 2014 Daniel Doubrovkine. All rights reserved.
+//
+
+#import "FUIViewController.h"
+
+@interface FUIViewController ()
+
+@end
+
+@implementation FUIViewController
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+	// Do any additional setup after loading the view, typically from a nib.
+}
+
+- (void)didReceiveMemoryWarning
+{
+    [super didReceiveMemoryWarning];
+    // Dispose of any resources that can be recreated.
+}
+
+@end

--- a/spec/fixtures/nibself/FUINib/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/spec/fixtures/nibself/FUINib/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,23 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/spec/fixtures/nibself/FUINib/Images.xcassets/LaunchImage.launchimage/Contents.json
+++ b/spec/fixtures/nibself/FUINib/Images.xcassets/LaunchImage.launchimage/Contents.json
@@ -1,0 +1,23 @@
+{
+  "images" : [
+    {
+      "orientation" : "portrait",
+      "idiom" : "iphone",
+      "extent" : "full-screen",
+      "minimum-system-version" : "7.0",
+      "scale" : "2x"
+    },
+    {
+      "orientation" : "portrait",
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "extent" : "full-screen",
+      "minimum-system-version" : "7.0",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/spec/fixtures/nibself/FUINib/en.lproj/InfoPlist.strings
+++ b/spec/fixtures/nibself/FUINib/en.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+/* Localized versions of Info.plist keys */
+

--- a/spec/fixtures/nibself/FUINib/main.m
+++ b/spec/fixtures/nibself/FUINib/main.m
@@ -1,0 +1,18 @@
+//
+//  main.m
+//  FUINib
+//
+//  Created by Daniel Doubrovkine on 2/7/14.
+//  Copyright (c) 2014 Daniel Doubrovkine. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+#import "FUIAppDelegate.h"
+
+int main(int argc, char * argv[])
+{
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([FUIAppDelegate class]));
+    }
+}

--- a/spec/fixtures/nibself/FUINibTests/FUINibTests-Info.plist
+++ b/spec/fixtures/nibself/FUINibTests/FUINibTests-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>Artsy.${PRODUCT_NAME:rfc1034identifier}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/spec/fixtures/nibself/FUINibTests/FUINibTests.m
+++ b/spec/fixtures/nibself/FUINibTests/FUINibTests.m
@@ -1,0 +1,34 @@
+//
+//  FUINibTests.m
+//  FUINibTests
+//
+//  Created by Daniel Doubrovkine on 2/7/14.
+//  Copyright (c) 2014 Daniel Doubrovkine. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+@interface FUINibTests : XCTestCase
+
+@end
+
+@implementation FUINibTests
+
+- (void)setUp
+{
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown
+{
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testExample
+{
+    XCTFail(@"No implementation for \"%s\"", __PRETTY_FUNCTION__);
+}
+
+@end

--- a/spec/fixtures/nibself/FUINibTests/en.lproj/InfoPlist.strings
+++ b/spec/fixtures/nibself/FUINibTests/en.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+/* Localized versions of Info.plist keys */
+

--- a/spec/fui/finder_spec.rb
+++ b/spec/fui/finder_spec.rb
@@ -15,13 +15,13 @@ describe Fui::Finder do
     end
     describe "#headers" do
       it "finds all headers" do
-        finder = Fui::Finder.new(@fixtures_dir, false)
+        finder = Fui::Finder.new(@fixtures_dir)
         finder.headers.map { |h| h.filename }.sort.should == ["unused_class.h", "used_class.h"]
       end
     end
     describe "#references" do
       it "maps references" do
-        finder = Fui::Finder.new(@fixtures_dir, false)
+        finder = Fui::Finder.new(@fixtures_dir)
         finder.references.size.should == 2
         Hash[finder.references.map { |k, v| [ k.filename,  v.count ]}].should == {
           "unused_class.h" => 0,
@@ -31,7 +31,7 @@ describe Fui::Finder do
     end
     describe "#unsed_references" do
       it "finds unused references" do
-        finder = Fui::Finder.new(@fixtures_dir, false)
+        finder = Fui::Finder.new(@fixtures_dir)
         Hash[finder.unused_references.map { |k, v| [ k.filename,  v.count ]}].should == {
           "unused_class.h" => 0
         }
@@ -44,7 +44,7 @@ describe Fui::Finder do
     end
     describe "#unsed_references" do
       it "finds unused references" do
-        finder = Fui::Finder.new(@fixtures_dir, false)
+        finder = Fui::Finder.new(@fixtures_dir)
         Hash[finder.unused_references.map { |k, v| [ k.filename,  v.count ]}].should == {
           "unused_class.h" => 0
         }
@@ -57,7 +57,7 @@ describe Fui::Finder do
     end
     describe "#unsed_references" do
       it "finds unused references" do
-        finder = Fui::Finder.new(@fixtures_dir, false)
+        finder = Fui::Finder.new(@fixtures_dir)
         Hash[finder.unused_references.map { |k, v| [ k.filename,  v.count ]}].should == {
           "header.h" => 0,
           "unused_class.h" => 0
@@ -71,7 +71,7 @@ describe Fui::Finder do
     end
     describe "#unsed_references" do
       it "finds no unused references" do
-        finder = Fui::Finder.new(@fixtures_dir, false)
+        finder = Fui::Finder.new(@fixtures_dir)
         finder.unused_references.count.should == 0
       end
     end
@@ -82,7 +82,7 @@ describe Fui::Finder do
     end
     describe "#unsed_references" do
       it "finds no unused references" do
-        finder = Fui::Finder.new(@fixtures_dir, false)
+        finder = Fui::Finder.new(@fixtures_dir)
         finder.unused_references.count.should == 0
       end
     end
@@ -93,7 +93,7 @@ describe Fui::Finder do
     end
     describe "#unsed_references" do
       it "finds one unused references" do
-        finder = Fui::Finder.new(@fixtures_dir, true)
+        finder = Fui::Finder.new(@fixtures_dir, {'excludeselfxib' => true})
         finder.unused_references.count.should == 1
       end
     end

--- a/spec/fui/finder_spec.rb
+++ b/spec/fui/finder_spec.rb
@@ -15,13 +15,13 @@ describe Fui::Finder do
     end
     describe "#headers" do
       it "finds all headers" do
-        finder = Fui::Finder.new(@fixtures_dir)
+        finder = Fui::Finder.new(@fixtures_dir, false)
         finder.headers.map { |h| h.filename }.sort.should == ["unused_class.h", "used_class.h"]
       end
     end
     describe "#references" do
       it "maps references" do
-        finder = Fui::Finder.new(@fixtures_dir)
+        finder = Fui::Finder.new(@fixtures_dir, false)
         finder.references.size.should == 2
         Hash[finder.references.map { |k, v| [ k.filename,  v.count ]}].should == {
           "unused_class.h" => 0,
@@ -31,7 +31,7 @@ describe Fui::Finder do
     end
     describe "#unsed_references" do
       it "finds unused references" do
-        finder = Fui::Finder.new(@fixtures_dir)
+        finder = Fui::Finder.new(@fixtures_dir, false)
         Hash[finder.unused_references.map { |k, v| [ k.filename,  v.count ]}].should == {
           "unused_class.h" => 0
         }
@@ -44,7 +44,7 @@ describe Fui::Finder do
     end
     describe "#unsed_references" do
       it "finds unused references" do
-        finder = Fui::Finder.new(@fixtures_dir)
+        finder = Fui::Finder.new(@fixtures_dir, false)
         Hash[finder.unused_references.map { |k, v| [ k.filename,  v.count ]}].should == {
           "unused_class.h" => 0
         }
@@ -57,7 +57,7 @@ describe Fui::Finder do
     end
     describe "#unsed_references" do
       it "finds unused references" do
-        finder = Fui::Finder.new(@fixtures_dir)
+        finder = Fui::Finder.new(@fixtures_dir, false)
         Hash[finder.unused_references.map { |k, v| [ k.filename,  v.count ]}].should == {
           "header.h" => 0,
           "unused_class.h" => 0
@@ -71,8 +71,30 @@ describe Fui::Finder do
     end
     describe "#unsed_references" do
       it "finds no unused references" do
-        finder = Fui::Finder.new(@fixtures_dir)
+        finder = Fui::Finder.new(@fixtures_dir, false)
         finder.unused_references.count.should == 0
+      end
+    end
+  end
+  context "excludeselfxib option set to false" do
+    before :each do
+      @fixtures_dir = File.expand_path(File.join(__FILE__, '../../fixtures/nibself'))
+    end
+    describe "#unsed_references" do
+      it "finds no unused references" do
+        finder = Fui::Finder.new(@fixtures_dir, false)
+        finder.unused_references.count.should == 0
+      end
+    end
+  end
+  context "excludeselfxib option set to true" do
+    before :each do
+      @fixtures_dir = File.expand_path(File.join(__FILE__, '../../fixtures/nibself'))
+    end
+    describe "#unsed_references" do
+      it "finds one unused references" do
+        finder = Fui::Finder.new(@fixtures_dir, true)
+        finder.unused_references.count.should == 1
       end
     end
   end


### PR DESCRIPTION
Sometimes you want to find if a class is unused even if it is referenced from its self XIB, the "excludeselfxib" option handle this case.

Example : 
- if this option is set to false (default) Foo.h will be marked as used if a Foo.xib reference the Foo class
- else if this option is set to true Foo.h will be marked as unused even if a Foo.xib reference the class (and if there is no other reference to Foo.h...)