### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ fui -x --path=~/source/project/Name find
 fui --path=~/source/project/Name delete --perform --prompt
 ```
 
-#### XCode Plugin
+#### Xcode Plugin
 
-Use [xcfui](https://github.com/jcavar/xcfui) for integration with XCode.
+Use [xcfui](https://github.com/jcavar/xcfui) for integration with Xcode.
 
 ## Contributing
 


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/
Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
