### PR TITLE
Adding a global switch that will check for global header imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.4.2 (Next)
 
 * Your contribution here.
+* [#28](https://github.com/dblock/fui/pull/28): Added `-g`, `--global` to add support for global imports (bracket notation) - [@jeffctown](https://github.com/jeffctown). 
 
 ### 0.4.1 (8/16/2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ### 0.4.2 (Next)
 
 * Your contribution here.
-* [#28](https://github.com/dblock/fui/pull/28): Added `-g`, `--global` to add support for global imports (bracket notation) - [@jeffctown](https://github.com/jeffctown). 
+
+* [#28](https://github.com/dblock/fui/pull/28): Added support for finding global imports (bracket notation).  Added ability to turn off global or local import checks through `-g`, `--ignore-global-imports` or `-l`, `--ignore-local-imports`.- [@jeffctown](https://github.com/jeffctown). 
 
 ### 0.4.1 (8/16/2017)
 

--- a/README.md
+++ b/README.md
@@ -34,11 +34,30 @@ fui --path=~/source/project/Name find
 
 #### Find Unused Classes in a Path Skipping Interface Builder (.xib) Files
 
-ForRunning `fui` with `-x` (or `--ignorexib`) will, for example, mark `Foo.h` as unused when `Foo.xib` holds a reference to the `Foo` class and no other references to Foo.h exist.
+ForRunning `fui` with `-x` (or `--ignore-xib-files`) will, for example, mark `Foo.h` as unused when `Foo.xib` holds a reference to the `Foo` class and no other references to Foo.h exist.
 
 ```
 fui -x --path=~/source/project/Name find
 ```
+
+#### Find Unused Classes in a Path Ignoring Local (quotation syntax) Imports
+
+For Running `fui` with `-l` (or `--ignore-local-imports`) will, for example, mark `Foo.h` as unused when `Bar.h` contains a local import of `Foo.h` (`#import Foo.h`)
+
+```
+fui -l --path=~/source/project/Name find
+
+``` 
+
+#### Find Unused Classes in a Path Ignoring Global (bracket syntax) Imports
+
+For Running `fui` with `-g` (or `--ignore-global-imports`) will, for example, mark `Foo.h` as unused when `Bar.h` contains a global import of `Foo.h` (`#import <Framework/Foo.h>`)
+
+```
+fui -g --path=~/source/project/Name find
+
+``` 
+
 
 #### Delete All Unused Class Files w/ Prompt
 

--- a/bin/fui
+++ b/bin/fui
@@ -9,6 +9,7 @@ program_desc 'Find unused imports in an Objective-C codebase.'
 flag [:p, :path], desc: 'Path to search.', default_value: Dir.pwd
 switch [:v, :verbose], desc: 'Produce verbose output.', default_value: false
 switch [:x, :ignorexib], desc: 'Ignore interface builder (.xib) files.', default_value: false
+switch [:g, :global], desc: 'Also checks for imports in global (angle bracket) format.', default_value: false
 
 default_command :find
 

--- a/bin/fui
+++ b/bin/fui
@@ -8,8 +8,9 @@ program_desc 'Find unused imports in an Objective-C codebase.'
 
 flag [:p, :path], desc: 'Path to search.', default_value: Dir.pwd
 switch [:v, :verbose], desc: 'Produce verbose output.', default_value: false
-switch [:x, :ignorexib], desc: 'Ignore interface builder (.xib) files.', default_value: false
-switch [:g, :global], desc: 'Also checks for imports in global (angle bracket) format.', default_value: false
+switch [:x, :'ignore-xib-files'], desc: 'Ignore interface builder (.xib) files.', default_value: false
+switch [:g, :'ignore-global-imports'], desc: 'Ignores imports using a global (angle bracket) format.', default_value: false
+switch [:l, :'ignore-local-imports'], desc: 'Ignores imports using a local (quote) format.', default_value: false
 
 default_command :find
 

--- a/lib/fui/finder.rb
+++ b/lib/fui/finder.rb
@@ -52,8 +52,8 @@ module Fui
         headers.each do |header|
           filename_without_extension = File.basename(path, File.extname(path))
           file_contents = File.read(file)
-          global_import_exists = global_imported(file_contents, header)
-          local_import_exists = local_imported(file_contents, header)
+          global_import_exists = !options['ignore-global-imports'] && global_imported(file_contents, header)
+          local_import_exists = !options['ignore-local-imports'] && local_imported(file_contents, header)
           references[header] << path if filename_without_extension != header.filename_without_extension && (local_import_exists || global_import_exists)
         end
       end
@@ -66,7 +66,7 @@ module Fui
     def global_imported(file_contents, header)
       escaped_header = Regexp.quote(header.filename)
       regex = '(#import\s{1}<.+\/' + escaped_header + '>)'
-      options['global'] && file_contents.match(regex)
+      file_contents.match(regex)
     end
 
     def process_xml(references, path)
@@ -74,7 +74,7 @@ module Fui
         yield path if block_given?
         headers.each do |header|
           filename_without_extension = File.basename(path, File.extname(path))
-          references[header] << path if (!options['ignorexib'] || filename_without_extension != header.filename_without_extension) && File.read(file).include?("customClass=\"#{header.filename_without_extension}\"")
+          references[header] << path if (!options['ignore-xib-files'] || filename_without_extension != header.filename_without_extension) && File.read(file).include?("customClass=\"#{header.filename_without_extension}\"")
         end
       end
     end

--- a/lib/fui/finder.rb
+++ b/lib/fui/finder.rb
@@ -65,7 +65,7 @@ module Fui
 
     def global_imported(file_contents, header)
       escaped_header = Regexp.quote(header.filename)
-      regex = "(#import\s{1}<.+\/" + escaped_header + ">)"
+      regex = '(#import\s{1}<.+\/' + escaped_header + '>)'
       options['global'] && file_contents.match(regex)
     end
 

--- a/lib/fui/finder.rb
+++ b/lib/fui/finder.rb
@@ -52,18 +52,18 @@ module Fui
         headers.each do |header|
           filename_without_extension = File.basename(path, File.extname(path))
           file_contents = File.read(file)
-          global_import_exists = is_global_imported(file_contents, header)
-          local_import_exists = is_local_imported(file_contents, header)
+          global_import_exists = global_imported(file_contents, header)
+          local_import_exists = local_imported(file_contents, header)
           references[header] << path if filename_without_extension != header.filename_without_extension && (local_import_exists || global_import_exists)
         end
       end
     end
 
-    def is_local_imported(file_contents, header)
+    def local_imported(file_contents, header)
       file_contents.include?("#import \"#{header.filename}\"")
     end
 
-    def is_global_imported(file_contents, header)
+    def global_imported(file_contents, header)
       escaped_header = Regexp.quote(header.filename)
       regex = "(#import\s{1}<.+\/" + escaped_header + ">)"
       options['global'] && file_contents.match(regex)

--- a/lib/fui/finder.rb
+++ b/lib/fui/finder.rb
@@ -52,18 +52,20 @@ module Fui
         headers.each do |header|
           filename_without_extension = File.basename(path, File.extname(path))
           file_contents = File.read(file)
-          global_import_exists = !options['ignore-global-imports'] && global_imported(file_contents, header)
-          local_import_exists = !options['ignore-local-imports'] && local_imported(file_contents, header)
+          global_import_exists = global_imported(file_contents, header)
+          local_import_exists = local_imported(file_contents, header)
           references[header] << path if filename_without_extension != header.filename_without_extension && (local_import_exists || global_import_exists)
         end
       end
     end
 
     def local_imported(file_contents, header)
+      return false if options['ignore-local-imports']
       file_contents.include?("#import \"#{header.filename}\"")
     end
 
     def global_imported(file_contents, header)
+      return false if options['ignore-global-imports']
       escaped_header = Regexp.quote(header.filename)
       regex = '(#import\s{1}<.+\/' + escaped_header + '>)'
       file_contents.match(regex)
@@ -74,7 +76,8 @@ module Fui
         yield path if block_given?
         headers.each do |header|
           filename_without_extension = File.basename(path, File.extname(path))
-          references[header] << path if (!options['ignore-xib-files'] || filename_without_extension != header.filename_without_extension) && File.read(file).include?("customClass=\"#{header.filename_without_extension}\"")
+          check_xibs = !options['ignore-xib-files']
+          references[header] << path if (check_xibs || filename_without_extension != header.filename_without_extension) && File.read(file).include?("customClass=\"#{header.filename_without_extension}\"")
         end
       end
     end

--- a/spec/fixtures/global_import/header.h
+++ b/spec/fixtures/global_import/header.h
@@ -1,0 +1,1 @@
+#import <framework/used_class.h>

--- a/spec/fixtures/global_import/unused_class.h
+++ b/spec/fixtures/global_import/unused_class.h
@@ -1,0 +1,8 @@
+//
+//  UnusedClass.h
+//  FUI
+//
+
+@interface UnusedClass
+
+@end

--- a/spec/fixtures/global_import/unused_class.m
+++ b/spec/fixtures/global_import/unused_class.m
@@ -1,0 +1,10 @@
+//
+//  UnusedClass.m
+//  FUI
+//
+
+#import "unused_class.h"
+
+@implementation UnusedClass
+
+@end

--- a/spec/fixtures/global_import/used_class.h
+++ b/spec/fixtures/global_import/used_class.h
@@ -1,0 +1,10 @@
+//
+//  ImageView.h
+//  FUI
+//
+
+#import <UIKit/UIKit.h>
+
+@interface ImageView
+- (NSString *)fooForBar;
+@end

--- a/spec/fixtures/global_import/used_class.m
+++ b/spec/fixtures/global_import/used_class.m
@@ -1,0 +1,13 @@
+//
+//  UsedClass.m
+//  FUI
+//
+
+#import "used_class.h"
+
+@implementation UsedClass
+- (NSString *)fooForBar
+{
+
+}
+@end

--- a/spec/fui/finder_spec.rb
+++ b/spec/fui/finder_spec.rb
@@ -130,7 +130,7 @@ describe Fui::Finder do
     describe '#unused_references' do
       it 'finds one unused global reference' do
         finder = Fui::Finder.new(@fixtures_dir, 'global' => true)
-        expect(Hash[finder.unused_references.map { |k, v| [k.filename, v.count] }]).to eq("header.h" => 0, "unused_class.h" => 0)
+        expect(Hash[finder.unused_references.map { |k, v| [k.filename, v.count] }]).to eq('header.h' => 0, 'unused_class.h' => 0)
       end
     end
   end
@@ -141,7 +141,7 @@ describe Fui::Finder do
     describe '#unused_references' do
       it 'finds no unused global references' do
         finder = Fui::Finder.new(@fixtures_dir, 'global' => false)
-        expect(Hash[finder.unused_references.map { |k, v| [k.filename, v.count] }]).to eq("header.h" => 0, "unused_class.h" => 0, "used_class.h" => 0)
+        expect(Hash[finder.unused_references.map { |k, v| [k.filename, v.count] }]).to eq('header.h' => 0, 'unused_class.h' => 0, 'used_class.h' => 0)
       end
     end
   end

--- a/spec/fui/finder_spec.rb
+++ b/spec/fui/finder_spec.rb
@@ -101,7 +101,7 @@ describe Fui::Finder do
       end
     end
   end
-  context 'ignorexib option set to false' do
+  context 'ignore-xib-files option set to false' do
     before :each do
       @fixtures_dir = File.expand_path(File.join(__FILE__, '../../fixtures/nibself'))
     end
@@ -112,13 +112,13 @@ describe Fui::Finder do
       end
     end
   end
-  context 'ignorexib option set to true' do
+  context 'ignore-xib-files option set to true' do
     before :each do
       @fixtures_dir = File.expand_path(File.join(__FILE__, '../../fixtures/nibself'))
     end
     describe '#unsed_references' do
       it 'finds one unused references' do
-        finder = Fui::Finder.new(@fixtures_dir, 'ignorexib' => true)
+        finder = Fui::Finder.new(@fixtures_dir, 'ignore-xib-files' => true)
         expect(finder.unused_references.count).to eq(1)
       end
     end
@@ -129,7 +129,7 @@ describe Fui::Finder do
     end
     describe '#unused_references' do
       it 'finds one unused global reference' do
-        finder = Fui::Finder.new(@fixtures_dir, 'global' => true)
+        finder = Fui::Finder.new(@fixtures_dir, 'ignore-global-imports' => false)
         expect(Hash[finder.unused_references.map { |k, v| [k.filename, v.count] }]).to eq('header.h' => 0, 'unused_class.h' => 0)
       end
     end
@@ -140,7 +140,7 @@ describe Fui::Finder do
     end
     describe '#unused_references' do
       it 'finds no unused global references' do
-        finder = Fui::Finder.new(@fixtures_dir, 'global' => false)
+        finder = Fui::Finder.new(@fixtures_dir, 'ignore-global-imports' => true)
         expect(Hash[finder.unused_references.map { |k, v| [k.filename, v.count] }]).to eq('header.h' => 0, 'unused_class.h' => 0, 'used_class.h' => 0)
       end
     end

--- a/spec/fui/finder_spec.rb
+++ b/spec/fui/finder_spec.rb
@@ -123,4 +123,26 @@ describe Fui::Finder do
       end
     end
   end
+  context 'global option set to true' do
+    before :each do
+      @fixtures_dir = File.expand_path(File.join(__FILE__, '../../fixtures/global_import'))
+    end
+    describe '#unused_references' do
+      it 'finds one unused global reference' do
+        finder = Fui::Finder.new(@fixtures_dir, 'global' => true)
+        expect(Hash[finder.unused_references.map { |k, v| [k.filename, v.count] }]).to eq("header.h" => 0, "unused_class.h" => 0)
+      end
+    end
+  end
+  context 'global option set to false' do
+    before :each do
+      @fixtures_dir = File.expand_path(File.join(__FILE__, '../../fixtures/global_import'))
+    end
+    describe '#unused_references' do
+      it 'finds no unused global references' do
+        finder = Fui::Finder.new(@fixtures_dir, 'global' => false)
+        expect(Hash[finder.unused_references.map { |k, v| [k.filename, v.count] }]).to eq("header.h" => 0, "unused_class.h" => 0, "used_class.h" => 0)
+      end
+    end
+  end
 end

--- a/spec/fui/finder_spec.rb
+++ b/spec/fui/finder_spec.rb
@@ -123,7 +123,7 @@ describe Fui::Finder do
       end
     end
   end
-  context 'global option set to true' do
+  context 'ignore global imports option set to true' do
     before :each do
       @fixtures_dir = File.expand_path(File.join(__FILE__, '../../fixtures/global_import'))
     end
@@ -134,7 +134,7 @@ describe Fui::Finder do
       end
     end
   end
-  context 'global option set to false' do
+  context 'ignore global imports option set to false' do
     before :each do
       @fixtures_dir = File.expand_path(File.join(__FILE__, '../../fixtures/global_import'))
     end


### PR DESCRIPTION
I work daily on an iOS App that has multiple frameworks that live in the same repository and are used by my app. When I use fui on my repo, I end up getting a lot of false positives that tell me that my frameworks have unused imports when they are actually used.  The reason the references are not found is because these framework classes are imported as global imports (#import <Framework/Class.h>).

This PR is to add a -g or --global switch to perform a regex against imports in this format.  Adding a regex does decrease performance time, so I thought it made sense to have this switch default to false to not affect computation time for users who do not need this functionality.    

Here are computation times for my project (it's a pretty big project, 500k+ lines).

Global Switch Disabled
real	3m38.529s
user	2m17.454s
sys	1m20.829s

Global Switch Enabled
real	5m20.673s
user	3m53.501s
sys	1m26.923s

Unit tests are included. 

FYI - I've never contributed to a ruby project before, so please don't hesitate to tell me if there are obvious improvements that can be made to this pull request (thank you Rubocop!).