### PR TITLE
Fix ArgumentError: invalid byte sequence in UTF-8 for non-UTF-8 files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.5.1 (Next)
 
 * [#45](https://github.com/dblock/fui/pull/45): Migrated from Travis CI to GitHub Actions with danger-pr-comment workflow - [@dblock](https://github.com/dblock).
+* [#37](https://github.com/dblock/fui/issues/37): Fixed `ArgumentError: invalid byte sequence in UTF-8` when processing files with non-UTF-8 encoding - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ### 0.5.0 (2018/12/19)

--- a/lib/fui/finder.rb
+++ b/lib/fui/finder.rb
@@ -84,26 +84,23 @@ module Fui
     end
 
     def process_code(references, path)
-      File.open(path) do |file|
-        yield path if block_given?
-        headers.each do |header|
-          filename_without_extension = File.basename(path, File.extname(path))
-          file_contents = File.read(file)
-          global_import_exists = global_imported(file_contents, header)
-          local_import_exists = local_imported(file_contents, header)
-          references[header] << path if filename_without_extension != header.filename_without_extension && (local_import_exists || global_import_exists)
-        end
+      yield path if block_given?
+      file_contents = File.read(path, encoding: 'binary').encode('UTF-8', invalid: :replace, undef: :replace)
+      headers.each do |header|
+        filename_without_extension = File.basename(path, File.extname(path))
+        global_import_exists = global_imported(file_contents, header)
+        local_import_exists = local_imported(file_contents, header)
+        references[header] << path if filename_without_extension != header.filename_without_extension && (local_import_exists || global_import_exists)
       end
     end
 
     def process_xml(references, path)
-      File.open(path) do |file|
-        yield path if block_given?
-        headers.each do |header|
-          filename_without_extension = File.basename(path, File.extname(path))
-          check_xibs = !options['ignore-xib-files']
-          references[header] << path if (check_xibs || filename_without_extension != header.filename_without_extension) && File.read(file).include?("customClass=\"#{header.filename_without_extension}\"")
-        end
+      yield path if block_given?
+      file_contents = File.read(path, encoding: 'binary').encode('UTF-8', invalid: :replace, undef: :replace)
+      headers.each do |header|
+        filename_without_extension = File.basename(path, File.extname(path))
+        check_xibs = !options['ignore-xib-files']
+        references[header] << path if (check_xibs || filename_without_extension != header.filename_without_extension) && file_contents.include?("customClass=\"#{header.filename_without_extension}\"")
       end
     end
   end

--- a/spec/fixtures/non_utf8/main.m
+++ b/spec/fixtures/non_utf8/main.m
@@ -1,0 +1,3 @@
+#import "used_class.h"
+// ÄãºÃ
+- void main() {}

--- a/spec/fixtures/non_utf8/used_class.h
+++ b/spec/fixtures/non_utf8/used_class.h
@@ -1,0 +1,8 @@
+//
+//  UsedClass.h
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UsedClass
+@end

--- a/spec/fui/finder_spec.rb
+++ b/spec/fui/finder_spec.rb
@@ -179,4 +179,19 @@ describe Fui::Finder do
       end
     end
   end
+  context 'files with non-UTF-8 encoding' do
+    before :each do
+      @fixtures_dir = File.expand_path(File.join(__FILE__, '../../fixtures/non_utf8'))
+    end
+    describe '#references' do
+      it 'handles non-UTF-8 encoded files without raising an error' do
+        finder = Fui::Finder.new(@fixtures_dir)
+        expect { finder.references }.not_to raise_error
+      end
+      it 'finds references in files with non-UTF-8 encoding' do
+        finder = Fui::Finder.new(@fixtures_dir)
+        expect(Hash[finder.references.map { |k, v| [k.filename, v.count] }]).to eq('used_class.h' => 1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #37.

## Problem

Files with non-UTF-8 encoding (e.g., GB2312/GB18030 commonly used in Chinese codebases on Windows) caused `ArgumentError: invalid byte sequence in UTF-8` when fui tried to match import patterns against file contents.

## Fix

Read files in binary mode and transcode to UTF-8, replacing any invalid byte sequences. This allows fui to gracefully handle files with any encoding while still correctly finding `#import` references.

## Changes

- `lib/fui/finder.rb`: Read files as binary then encode to UTF-8 (replacing invalid bytes) in `process_code` and `process_xml`. Also removed the unnecessary `File.open` wrapper since `File.read` was re-opening the file anyway.
- `spec/fui/finder_spec.rb`: Added test cases for non-UTF-8 encoded files.
- `spec/fixtures/non_utf8/`: Added fixture files including a `.m` file with GB2312-encoded bytes (invalid UTF-8).