### PR TITLE
Fix NameError: undefined local variable or method 'project_path' in verbose mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [#45](https://github.com/dblock/fui/pull/45): Migrated from Travis CI to GitHub Actions with danger-pr-comment workflow - [@dblock](https://github.com/dblock).
 * [#37](https://github.com/dblock/fui/issues/37): Fixed `ArgumentError: invalid byte sequence in UTF-8` when processing files with non-UTF-8 encoding - [@dblock](https://github.com/dblock).
+* [#42](https://github.com/dblock/fui/issues/42): Fixed `NameError: undefined local variable or method 'project_path'` in verbose mode - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ### 0.5.0 (2018/12/19)

--- a/lib/fui/project.rb
+++ b/lib/fui/project.rb
@@ -22,7 +22,7 @@ module Fui
 
           path_tokens = tokens[1].split('/')
           bridging_header = path_tokens[path_tokens.length - 1]
-          puts "Bridging Header Found: #{bridging_header} in #{project_path}." if verbose
+          puts "Bridging Header Found: #{bridging_header} in #{path}." if verbose
           bridging_headers << bridging_header
         end
         bridging_headers.uniq

--- a/spec/fui/project_spec.rb
+++ b/spec/fui/project_spec.rb
@@ -24,6 +24,10 @@ describe Fui::Project do
       project = Fui::Project.new(@fixture)
       expect(project.bridging_headers(false)).to eq(['BridgingHeaderSpec-Bridging-Header.h'])
     end
+    it 'bridging headers are found in verbose mode' do
+      project = Fui::Project.new(@fixture)
+      expect { project.bridging_headers(true) }.not_to raise_error
+    end
   end
   describe '#bridging_headers' do
     before :each do


### PR DESCRIPTION
Fixes #42.

## Problem

Running fui with `--verbose` raised a `NameError: undefined local variable or method 'project_path'` when a bridging header was found. The code in `Fui::Project#bridging_headers` referenced `project_path` which doesn't exist.

## Fix

Replace `project_path` with `path`, which is already available as an `attr_accessor` on the instance.

## Changes

- `lib/fui/project.rb`: Replace `project_path` with `path` on line 25.
- `spec/fui/project_spec.rb`: Added a test for `bridging_headers` in verbose mode.