### PR TITLE
Fix delete command to also remove .mm implementation files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ### 0.5.1 (Next)
 
 * [#45](https://github.com/dblock/fui/pull/45): Migrated from Travis CI to GitHub Actions with danger-pr-comment workflow - [@dblock](https://github.com/dblock).
-* [#37](https://github.com/dblock/fui/issues/37): Fixed `ArgumentError: invalid byte sequence in UTF-8` when processing files with non-UTF-8 encoding - [@dblock](https://github.com/dblock).
-* [#42](https://github.com/dblock/fui/issues/42): Fixed `NameError: undefined local variable or method 'project_path'` in verbose mode - [@dblock](https://github.com/dblock).
-* [#38](https://github.com/dblock/fui/issues/38): Added summary output to `find` command: prints `Found N unused header(s).` or `No unused imports found.` - [@dblock](https://github.com/dblock).
+* [#47](https://github.com/dblock/fui/pull/47): Fixed `ArgumentError: invalid byte sequence in UTF-8` when processing files with non-UTF-8 encoding - [@dblock](https://github.com/dblock).
+* [#48](https://github.com/dblock/fui/pull/48): Fixed `NameError: undefined local variable or method 'project_path'` in verbose mode - [@dblock](https://github.com/dblock).
+* [#49](https://github.com/dblock/fui/pull/49): Added summary output to `find` command: prints `Found N unused header(s).` or `No unused imports found.` - [@dblock](https://github.com/dblock).
+* [#50](https://github.com/dblock/fui/pull/50): Fixed `delete` command to also remove `.mm` (Objective-C++) implementation files - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ### 0.5.0 (2018/12/19)

--- a/bin/fui
+++ b/bin/fui
@@ -63,7 +63,7 @@ command :delete do |c|
       end.each do |k, _v|
         relative_path = Pathname.new(k.path).relative_path_from(root).to_s
         if options[:prompt]
-          print "Remove #{relative_path}(.m) [y/N] "
+          print "Remove #{relative_path}(.m/.mm) [y/N] "
           response = STDIN.getc.upcase
           puts "#{response.chr}\r\n"
           next unless response.chr == 'Y'
@@ -74,16 +74,18 @@ command :delete do |c|
           puts "#{relative_path}#{options[:perform] ? '' : ' (simulation)'}\r\n"
         end
         File.delete(k.path) if options[:perform]
-        impl_path = k.path.gsub(/\.h$/, '.m')
-        next unless File.exist?(impl_path)
+        ['.m', '.mm'].each do |ext|
+          impl_path = k.path.gsub(/\.h$/, ext)
+          next unless File.exist?(impl_path)
 
-        relative_path = Pathname.new(impl_path).relative_path_from(root).to_s
-        if global_options[:verbose]
-          puts "Removing #{relative_path}#{options[:perform] ? '' : ' (simulation)'}\r\n"
-        else
-          puts "#{relative_path}#{options[:perform] ? '' : ' (simulation)'}\r\n"
+          relative_path = Pathname.new(impl_path).relative_path_from(root).to_s
+          if global_options[:verbose]
+            puts "Removing #{relative_path}#{options[:perform] ? '' : ' (simulation)'}\r\n"
+          else
+            puts "#{relative_path}#{options[:perform] ? '' : ' (simulation)'}\r\n"
+          end
+          File.delete(impl_path) if options[:perform]
         end
-        File.delete(impl_path) if options[:perform]
       end
     ensure
       system('stty -raw echo')

--- a/spec/fui/fui_spec.rb
+++ b/spec/fui/fui_spec.rb
@@ -70,5 +70,25 @@ describe Fui do
       end
       pending 'prompts for deletion'
     end
+    describe '#delete with .mm files' do
+      before :each do
+        @mm_fixtures = File.expand_path(File.join(__FILE__, '../../fixtures/mm'))
+      end
+      it "doesn't delete .mm files by default" do
+        output = `"#{@binary}" --verbose --path "#{@mm_fixtures}" delete --no-prompt`
+        output = output.split("\r\n")
+        expect(output).to include 'Removing unused_class.mm (simulation)'
+        expect(File.exist?(File.join(@mm_fixtures, 'unused_class.mm'))).to be true
+      end
+      it 'deletes .mm files with --perform' do
+        Dir.mktmpdir do |tmpdir|
+          FileUtils.cp_r @mm_fixtures.to_s, tmpdir
+          output = `"#{@binary}" --verbose --path "#{tmpdir}" delete --no-prompt --perform`
+          output = output.split("\r\n")
+          expect(output).to include 'Removing mm/unused_class.mm'
+          expect(File.exist?(File.join(tmpdir, 'mm/unused_class.mm'))).to be false
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #12.

## Problem

The `delete` command only looked for `.m` implementation files when removing an unused header. In projects with Objective-C++ (`.mm`) files, the implementation file would be left behind.

## Changes

- Iterates over both `.m` and `.mm` extensions when looking for implementation files to delete
- Updated the prompt text from `(.m)` to `(.m/.mm)`
- Added tests covering the `.mm` case (simulation and `--perform`)